### PR TITLE
Feature: Allow users to manually include prescriber copies for any prescription

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "globals": {
+      "google": {}
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/public/index.html
+++ b/public/index.html
@@ -2,9 +2,7 @@
 <html lang="en">
 
 <head>
-  <!-- <meta 
-      http-equiv="Content-Security-Policy" 
-      content="
+  <meta http-equiv="Content-Security-Policy" content="
         default-src 'none';  
         script-src 'self' https://*.googleapis.com https://*.gstatic.com *.google.com https://*.ggpht.com *.googleusercontent.com https://cdn.firebase.com https://*.firebaseio.com;
         style-src 'self' 'unsafe-inline'; 
@@ -14,8 +12,7 @@
         connect-src 'self' https://*.googleapis.com *.google.com https://*.gstatic.com  data: blob:;
         base-uri 'self';
         form-action 'none';
-      "
-    > -->
+      ">
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta 
+
+<head>
+  <!-- <meta 
       http-equiv="Content-Security-Policy" 
       content="
         default-src 'none';  
@@ -14,19 +15,19 @@
         base-uri 'self';
         form-action 'none';
       "
-    >
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Giving Australian optometrists the tools to professionally create and manage therapeutic prescriptions online, including PBS and authority scripts."/>
-    <link rel=”shortcut icon” href=”%PUBLIC_URL%/favicon.ico”>
-    <title>Online therapeutic prescriptions for Optometrists · OptomRx</title>
-    
-  </head>
-  <body>
-    <div id="root"></div>
-  </body>
+    > -->
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description"
+    content="Giving Australian optometrists the tools to professionally create and manage therapeutic prescriptions online, including PBS and authority scripts." />
+  <link rel=”shortcut icon” href=”%PUBLIC_URL%/favicon.ico”>
+  <title>Online therapeutic prescriptions for Optometrists · OptomRx</title>
+
+</head>
+
+<body>
+  <div id="root"></div>
+</body>
+
 </html>
-
-
-

--- a/src/components/AddPrescriber/AddPrescriber.js
+++ b/src/components/AddPrescriber/AddPrescriber.js
@@ -1,3 +1,4 @@
+/*global google*/
 import { useNavigate } from "react-router-dom";
 import { addDoc, collection } from "firebase/firestore";
 import { useState, useEffect } from "react";
@@ -36,10 +37,10 @@ const AddPrescriber = ({ googleLoaded, setToast, setPage }) => {
     setPage(null);
   }, [setPage])
 
-  
+
   // Used when the user submits the form - saves a new prescriber referenced by their user ID
   const handleSubmit = async (event) => {
-    event.preventDefault(); 
+    event.preventDefault();
     setIsPending(true);
 
     try {
@@ -59,7 +60,7 @@ const AddPrescriber = ({ googleLoaded, setToast, setPage }) => {
       setIsPending(false);
       // Throw error toast on screen, no further rendering is required, nor any specific error handling
       showErrorToast(setToast, 'An error occurred while adding prescriber')
-    }     
+    }
   };
 
   const cancelEdit = () => {
@@ -69,16 +70,16 @@ const AddPrescriber = ({ googleLoaded, setToast, setPage }) => {
   return (<>
     <Helmet>
       <title>Add prescriber · OptomRx</title>
-      <meta name="description" content="Add a new prescriber profile for use with your prescriptions."/>
+      <meta name="description" content="Add a new prescriber profile for use with your prescriptions." />
       <link rel="canonical" href="/add-prescriber" />
     </Helmet>
     <ContentContainer>
       <StyledAddPrescriber>
-        <PageHeader title="Add prescriber" description="Prescriber details will appear on your prescriptions"/>
+        <PageHeader title="Add prescriber" description="Prescriber details will appear on your prescriptions" />
         <div className="form-container">
           <span className="form-title">Prescriber details</span>
-          <PrescriberForm 
-            googleLoaded={googleLoaded} 
+          <PrescriberForm
+            googleLoaded={googleLoaded}
             data={prescriberData}
             setData={setPrescriberData}
             handleSubmit={handleSubmit}

--- a/src/components/AddPrescriber/AddPrescriber.test.js
+++ b/src/components/AddPrescriber/AddPrescriber.test.js
@@ -1,0 +1,21 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { AuthContextProvider } from '../../context/AuthContext';
+import AddPrescriber from "./AddPrescriber";
+import { HelmetProvider } from 'react-helmet-async';
+
+it("Displays correct header", async () => {
+  render(
+    <BrowserRouter>
+      <HelmetProvider>
+        <AuthContextProvider>
+          <AddPrescriber setPage={jest.fn} setToast={jest.fn} googleLoaded={true} />
+        </AuthContextProvider>
+      </HelmetProvider>
+    </BrowserRouter>
+  );
+
+  const header = screen.getByRole('heading');
+
+  await waitFor(() => { expect(header).toBeInTheDocument() });
+});

--- a/src/components/PrescriberForm/PrescriberForm.js
+++ b/src/components/PrescriberForm/PrescriberForm.js
@@ -39,19 +39,19 @@ const PrescriberForm = ({ data, setData, googleLoaded, handleSubmit, handleCance
         case name === 'streetAddress':
           validateRequiredField(setPrescriberAlerts, event.target);
           break;
-        
+
         case name === 'suburb':
           validateRequiredField(setPrescriberAlerts, event.target);
           break;
-  
+
         case name === 'state':
           setData((prevData) => ({
-            ...prevData, 
-            [name]: abbreviateStateName(value), 
+            ...prevData,
+            [name]: abbreviateStateName(value),
           }));
           validateRequiredField(setPrescriberAlerts, event.target);
           break;
-  
+
         case name === 'postcode':
           validateRequiredField(setPrescriberAlerts, event.target);
           break;
@@ -75,11 +75,11 @@ const PrescriberForm = ({ data, setData, googleLoaded, handleSubmit, handleCance
             positiveValidationUI(setPrescriberAlerts, event.target);
           }
           break;
-      
+
         default:
           break;
       }
-    });    
+    });
   }, [setData, negativeValidationUI, positiveValidationUI, validateRequiredField, abbreviateStateName]);
 
   // Ensure form is validated with no empty required fields before calling form submission function
@@ -115,109 +115,109 @@ const PrescriberForm = ({ data, setData, googleLoaded, handleSubmit, handleCance
 
   return (
     // Legal requirements include the prescriber's name, address, contact details, and prescriber number
-      <StyledPrescriberForm className="PrescriberForm" autoComplete="off" noValidate onSubmit={(event) => {
-        event.preventDefault(); 
-        if (checkFormValidation()) {
-          handleSubmit(event);
-        }
-      }}>
-        <div className="fields">
-          {formPending && <LoadOverlay />}
+    <StyledPrescriberForm className="PrescriberForm" autoComplete="off" noValidate onSubmit={(event) => {
+      event.preventDefault();
+      if (checkFormValidation()) {
+        handleSubmit(event);
+      }
+    }}>
+      <div className="fields">
+        {formPending && <LoadOverlay />}
 
-          <FormField 
-            fieldType="text" 
-            name="fullName"
-            label="Full name" 
-            value={data.fullName} 
-            onChange={(event) => handleChange(event, setData)} 
-            alert={prescriberAlerts.fullName}
-            required
-          />    
+        <FormField
+          fieldType="text"
+          name="fullName"
+          label="Full name"
+          value={data.fullName}
+          onChange={(event) => handleChange(event, setData)}
+          alert={prescriberAlerts.fullName}
+          required
+        />
 
-          <FormField 
-            fieldType="checkbox" 
-            name="prefix"
-            label="Include 'Dr' in prescriber name" 
-            onChange={() => toggleBooleanState(setData, data, 'prefix')}
-            checked={data.prefix}
-            className="checkbox prefix-field"
-            enterFunc={(event) => handleEnterKeyOnCheckbox(event, setData, data)}
-          />  
+        <FormField
+          fieldType="checkbox"
+          name="prefix"
+          label="Include 'Dr' in prescriber name"
+          onChange={() => toggleBooleanState(setData, data, 'prefix')}
+          checked={data.prefix}
+          className="checkbox prefix-field"
+          enterFunc={(event) => handleEnterKeyOnCheckbox(event, setData, data)}
+        />
 
-          <FormField 
-            fieldType="text" 
-            name="qualifications"
-            label="Abbreviated qualifications (optional)" 
-            placeholder="e.g. BMedSci(VisSc), MOpt"
-            value={data.qualifications} 
-            onChange={(event) => handleChange(event, setData)} 
-            maxlength="40"
-          />
+        <FormField
+          fieldType="text"
+          name="qualifications"
+          label="Abbreviated qualifications (optional)"
+          placeholder="e.g. BMedSci(VisSc), MOpt"
+          value={data.qualifications}
+          onChange={(event) => handleChange(event, setData)}
+          maxlength="40"
+        />
 
-          {/* Practice name is only used for display purposes to quickly identify the prescriber to the user */}
-          <FormField 
-            name="practiceName"
-            label="Practice name (optional)" 
-            value={data.practiceName} 
-            onChange={(event) => handleChange(event, setData)} 
-          />
+        {/* Practice name is only used for display purposes to quickly identify the prescriber to the user */}
+        <FormField
+          name="practiceName"
+          label="Practice name (optional)"
+          value={data.practiceName}
+          onChange={(event) => handleChange(event, setData)}
+        />
 
-          <AddressAutocomplete 
-            data={data}
-            setData={setData}
-            handleChange={(event) => handleChange(event, setData)}
-            prescriber={true}   
-            alerts={prescriberAlerts}
-            setAlerts={setPrescriberAlerts} 
-            googleLoaded={googleLoaded}
-          />
+        <AddressAutocomplete
+          data={data}
+          setData={setData}
+          handleChange={(event) => handleChange(event, setData)}
+          prescriber={true}
+          alerts={prescriberAlerts}
+          setAlerts={setPrescriberAlerts}
+          googleLoaded={googleLoaded}
+        />
 
-          <FormField 
-            fieldType="text" 
-            name="phoneNumber"
-            label="Phone number" 
-            value={data.phoneNumber} 
-            onChange={(event) => handleChange(event, setData)} 
-            alert={prescriberAlerts.phoneNumber}
-            id="phoneNumber"
-            maxlength="10"
-            className="phoneNo-field form-field"
-            required
-          />
+        <FormField
+          fieldType="text"
+          name="phoneNumber"
+          label="Phone number"
+          value={data.phoneNumber}
+          onChange={(event) => handleChange(event, setData)}
+          alert={prescriberAlerts.phoneNumber}
+          id="phoneNumber"
+          maxlength="10"
+          className="phoneNo-field form-field"
+          required
+        />
 
-          <FormField 
-            fieldType="text" 
-            name="prescriberNumber"
-            label="Prescriber number" 
-            value={data.prescriberNumber} 
-            onChange={(event) => handleChange(event, setData)} 
-            alert={prescriberAlerts.prescriberNumber}
-            maxlength="7"
-            className="prescriberNo-field form-field"
-            required
-          />
-        </div>
-       
-        <div className="PrescriberForm__btns">
-          <Button classLabel="submit" type="submit">
-            {pending ? (
-              <Dots color="white" />
-              ) : (
-              `${submitBtnLabel}`
-            )}
-          </Button>
+        <FormField
+          fieldType="text"
+          name="prescriberNumber"
+          label="Prescriber number"
+          value={data.prescriberNumber}
+          onChange={(event) => handleChange(event, setData)}
+          alert={prescriberAlerts.prescriberNumber}
+          maxlength="7"
+          className="prescriberNo-field form-field"
+          required
+        />
+      </div>
 
-          <Button 
-            design="secondary" 
-            handleClick={(event) => {
-              event.preventDefault(); 
-              handleCancel();
-            }}>
-            Cancel
-          </Button>
-        </div>
-      </StyledPrescriberForm>
-    )
+      <div className="PrescriberForm__btns">
+        <Button classLabel="submit" type="submit">
+          {pending ? (
+            <Dots color="white" />
+          ) : (
+            `${submitBtnLabel}`
+          )}
+        </Button>
+
+        <Button
+          design="secondary"
+          handleClick={(event) => {
+            event.preventDefault();
+            handleCancel();
+          }}>
+          Cancel
+        </Button>
+      </div>
+    </StyledPrescriberForm>
+  )
 }
 
 export default PrescriberForm;

--- a/src/components/RxTemplate/RxTemplate.js
+++ b/src/components/RxTemplate/RxTemplate.js
@@ -15,6 +15,7 @@ import { useFormatting } from "../../hooks/useFormatting";
 import { useImmediateToast } from '../../hooks/useImmediateToast';
 import { Helmet } from "react-helmet-async";
 import { DateTime } from "luxon";
+import FormField from '../FormField/FormField';
 
 const RxTemplate = ({ data, setToast, setPage, resetData }) => {
   // Deconstructing data for cleanliness of code and easier-to-understand operations
@@ -25,8 +26,23 @@ const RxTemplate = ({ data, setToast, setPage, resetData }) => {
   const { showSuccessToast, showErrorToast } = useImmediateToast();
 
   const [isPending, setIsPending] = useState(false);
+  const [includePrescriberCopy, setIncludePrescriberCopy] = useState(false);
 
   const dateTimePrescribed = DateTime.now().toLocaleString(DateTime.DATETIME_MED);
+
+  // Handle any input controlling boolean data, typically checkboxes
+  const toggleIncludePrescriber = () => {
+    setIncludePrescriberCopy((prevState) => !prevState)
+  };
+
+  // Ensure that pressing the enter key on checkboxes functions as expected without submitting any forms
+  const handleEnterKeyOnCheckbox = (event) => {
+    // If the enter key is pressed
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      toggleIncludePrescriber();
+    }
+  }
 
   // Adjust current page for accessibility and styling
   useEffect(() => {
@@ -61,15 +77,13 @@ const RxTemplate = ({ data, setToast, setPage, resetData }) => {
     } catch (error) {
       setIsPending(false);
       showErrorToast(setToast, 'An error occurred while saving the script');
-    } finally {
-      
     }
   };
 
   return (<>
     <Helmet>
       <title>Review prescription · OptomRx</title>
-      <meta name="description" content="Review your prescription before printing. Make changes as needed, and save once complete."/>
+      <meta name="description" content="Review your prescription before printing. Make changes as needed, and save once complete." />
       <link rel="canonical" href="/review-prescription" />
     </Helmet>
     <StyledRxTemplate className="RxTemplate">
@@ -149,6 +163,18 @@ const RxTemplate = ({ data, setToast, setPage, resetData }) => {
                 <div className="ui-justification">{`Clinical justification for use of item: ${miscData.justification === "" ? 'None provided' : miscData.justification}`}</div>
               </div>
             </div>)}
+            <div className="include-prescriber ui-info">
+              <FormField
+                fieldType="checkbox"
+                name="includePrescriber"
+                label="Include prescriber copy"
+                onChange={toggleIncludePrescriber}
+                //! Prescriber copy MUST be included on authority PBS scripts
+                checked={includePrescriberCopy || drugData.authRequired}
+                className="checkbox"
+                enterFunc={handleEnterKeyOnCheckbox}
+              />
+            </div>
           </section>
         </div>
 
@@ -323,7 +349,7 @@ const RxTemplate = ({ data, setToast, setPage, resetData }) => {
         </div>
 
         <div className="lower-containers">
-          {drugData.authRequired && <div className="bottom-container--left">
+          {(includePrescriberCopy) && <div className="bottom-container--left">
             <span className="doctor-copy">--Prescriber's Copy--</span>
             <section className="prescriber-upper">
               <div className="container">

--- a/src/components/RxTemplate/RxTemplate.js
+++ b/src/components/RxTemplate/RxTemplate.js
@@ -26,7 +26,7 @@ const RxTemplate = ({ data, setToast, setPage, resetData }) => {
   const { showSuccessToast, showErrorToast } = useImmediateToast();
 
   const [isPending, setIsPending] = useState(false);
-  const [includePrescriberCopy, setIncludePrescriberCopy] = useState(false);
+  const [includePrescriberCopy, setIncludePrescriberCopy] = useState(true);
 
   const dateTimePrescribed = DateTime.now().toLocaleString(DateTime.DATETIME_MED);
 

--- a/src/components/RxTemplate/RxTemplate.styled.js
+++ b/src/components/RxTemplate/RxTemplate.styled.js
@@ -67,6 +67,7 @@ const StyledRxTemplate = styled.div`
       padding: 0;
       .label-text {
         margin-top: -0.15rem;
+        font-weight: 600;
       }
     }
   }

--- a/src/components/RxTemplate/RxTemplate.styled.js
+++ b/src/components/RxTemplate/RxTemplate.styled.js
@@ -60,6 +60,15 @@ const StyledRxTemplate = styled.div`
     .ui-auth, .ui-justification {
       padding-top: 0.5rem;
     }
+
+    /* Styling for the 'include prescriber copy' checkbox */
+    .checkbox {
+      margin: 0.25rem 0;
+      padding: 0;
+      .label-text {
+        margin-top: -0.15rem;
+      }
+    }
   }
 
   .RxTemplate__btns {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,13 @@
 import '@testing-library/jest-dom';
+
+// Setup global 'google' variable to avoid the ReferenceError involing the 'google' var
+window.google = {
+  maps: {
+    places: {
+      Autocomplete: function () {
+        return { addListener: jest.fn() };
+      },
+      event: { trigger: jest.fn() }
+    }
+  }
+};


### PR DESCRIPTION
**1. Because:**

There is some confusion amongst users as to which prescriptions should be retained, and how to retain non-authority scripts. To enable optometrists to keep copies of any script for their records, an option is needed to allow prescriber copies on all scripts.

**2. This PR:**

Adds a checkbox input to the Rx preview page that offers the option to include a prescriber copy. This defaults to true, and is set to true (and cannot be changed) when the script is an authority script.

**3. Additional Information:**

Following this change, an update should be made to the FAQ regarding this topic.
